### PR TITLE
Adjust language tag in readme code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ or
 
 Hide a folder from your git revision history.
 
-```.gitignore
+```text:title=.gitignore
 /content
 ```
 


### PR DESCRIPTION
This is to silence prism highlighter warnings -- `.gitignore` is not on the list of [officially supported language tags](https://prismjs.com/#languages-list). Thanks!